### PR TITLE
Add missing SNS Topic Policy

### DIFF
--- a/cloudformation_files/etl_automation.yaml
+++ b/cloudformation_files/etl_automation.yaml
@@ -181,6 +181,18 @@ Resources:
           Protocol: "email"
       TopicName: 'BatchProcessingErrorsTopic'
 
+  ErrorsTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sns:Publish
+            Resource: '*'
+      Topics:
+        - !Ref ErrorsTopic
 
   #CronJob as EventRule to invoke AWS batch
   CronjobEvent:


### PR DESCRIPTION
While using this sample for my own purposes I came to the conclusion the reason my failed events weren't being published to the SNS topic was because the topic policy was missing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
